### PR TITLE
Empty string regex output case

### DIFF
--- a/src/Plugins/regex.py
+++ b/src/Plugins/regex.py
@@ -62,7 +62,10 @@ class Plugin:
                                     body = body.replace('\\\\', '\\')
 
                                     # send it
-                                    self.controller.privmsg(msg.channel, '%s meant to say: %s' % (msg.nick, body))
+                                    if body == "":
+                                        self.controller.privmsg(msg.channel, '%s said nothing' % msg.nick)
+                                    else:
+                                        self.controller.privmsg(msg.channel, '%s meant to say: %s' % (msg.nick, body))
 
                                     break
                             except:


### PR DESCRIPTION
Instead of writing "User meant to say: ", the regex module now writes "User said nothing".
