### PR TITLE
Disabling end of challenge congrats message

### DIFF
--- a/src/Plugins/congrats.py
+++ b/src/Plugins/congrats.py
@@ -2,7 +2,7 @@ import time
 from apis import ncss
 
 class Plugin:
-    active = True
+    active = False
 
     def __init__(self, controller):
         self.controller       = controller


### PR DESCRIPTION
It was only coded to be used once, so now the time has passed it has to be disabled otherwise NCSSBot spams when restarted.

Could be made configurable in future
