### PR TITLE
web/linkinfo: sanitise title whitespace

### DIFF
--- a/plugins/web/linkinfo.py
+++ b/plugins/web/linkinfo.py
@@ -47,6 +47,7 @@ class Plugin(object):
 					if title is None:
 						return
 					title = self.utils.tag_to_string(title)
+					title = ' '.join(title.split())
 					message = "Title: " + title
 
 				# Other resources


### PR DESCRIPTION
This fixes the common webpage where newlines are found within `<title>` tags (which is also a message injection issue).
