### PR TITLE
Fix regexps not modifying what the user said

### DIFF
--- a/plugins/misc/regex.py
+++ b/plugins/misc/regex.py
@@ -104,7 +104,11 @@ class Plugin(object):
 					else:
 						# Was invalid, return without adding to last messages
 						return
-
+			their_messages = self.last_messages[msg.nick]
+			their_messages.appendleft(body)
+			if len(their_messages) > self.backlog:
+				their_messages.pop()
+			return
 		# Add it to the last messages dictionary
 		their_messages = self.last_messages[msg.nick]
 		their_messages.appendleft(msg.body)


### PR DESCRIPTION
Now regexps actually change what the user said, so that multiple 's/x/y/' change progressively.
