### PR TITLE
linkinfo: don't GET redirects, show real filenames

### DIFF
--- a/plugins/web/linkinfo.py
+++ b/plugins/web/linkinfo.py
@@ -29,6 +29,8 @@ class Plugin(object):
 					url = url[1:-1]
 
 				head = requests.head(url, allow_redirects=True)
+				# work on the URL we were redirected to, if any
+				url = head.url
 
 				message = ""
 				content_type = head.headers['content-type']


### PR DESCRIPTION
We shouldn't be wasting time getting redirects again if we already know where a redirect leads to.
We should also show the filename we were redirected to, if we were redirected.

(yes, I used the GitHub editor for this. kill me.)
