### PR TITLE
ignore: list of nicks to ignore in config

### DIFF
--- a/.ninjabot_config
+++ b/.ninjabot_config
@@ -68,5 +68,13 @@
        More will be added as I discover them. (They require different parameters)
      */
     "mode": "acc"
+  },
+
+  "core.ignore": {
+    /* List of nicks to ignore by default */
+    "ignorelist": [
+      "ignore1",
+      "ignore2"
+    ]
   }
 }

--- a/plugins/core/ignore.py
+++ b/plugins/core/ignore.py
@@ -2,6 +2,8 @@ class Plugin(object):
 	def load(self, bot, config):
 		self.bot = bot
 		self.timeouts = {}
+		if 'ignorelist' in config:
+			self.bot.ignored += config['ignorelist']
 
 	def on_incoming(self, msg):
 		if msg.command == 'NICK':


### PR DESCRIPTION
Load a predefined list `ignorelist` of nicks to automatically ignore. Nothing happens if `ignorelist` doesn't exist in the config.
